### PR TITLE
[Alternative] Mavenize project - mark sources roots based on old repository layout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,21 +7,64 @@
     <groupId>com.acclash.jdosbox</groupId>
     <artifactId>jdosbox-root</artifactId>
     <version>0.74.31-SNAPSHOT</version>
-    <packaging>pom</packaging>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.javassist</groupId>
-                <artifactId>javassist</artifactId>
-                <version>3.14.0-GA</version>
-            </dependency>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.14.0-GA</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source></source>
+                    <compileSourceRoots>
+                        <compileSourceRoot>${basedir}/src</compileSourceRoot>
+                        <compileSourceRoot>${basedir}/src_compiler</compileSourceRoot>
+                        <compileSourceRoot>${basedir}/src_j2se</compileSourceRoot>
+                    </compileSourceRoots>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>jdos.gui.MainFrame</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Adding the build system, proposition No. 1:
Use Maven to compile the project adding separate source roots defined in the original repository. 
These are not standalone modules, as they have dependencies on one another, so they either need to be included into maven build selectively as is here, or the source roots needs to be merged into single dir and follow maven conventional layout (second PR). 

This here has an advantage of flexibility - as there is several variants of output, depending on which roots are included in the build, these can be expressed by specific maven profiles, each selecting applicable source roots.

The disadvantage is poor tooling support. For example IDE may be confused and not detect sources, even if commandline mvn creates expected output. Besides fighing maven conventions is a lost cause, even if battles are being won here and there.